### PR TITLE
Add timer to bar

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,6 +1,6 @@
 [MASTER]
 # Load modules inside anki folder
-init-hook='import sys, os; sys.path.append(os.getcwd() + '/anki-2.0.52')'
+init-hook='import sys, os; sys.path.append(os.getcwd() + \'/anki-2.0.52\')'
 # Members inside aqt.qt module are not recognized by pylint
 extension-pkg-whitelist=aqt.qt
 

--- a/lifedrain/lifedrain.py
+++ b/lifedrain/lifedrain.py
@@ -38,7 +38,7 @@ TEXT_FORMAT = [
     {'text': 'current/total', 'format': '%v/%m'},
     {'text': 'current', 'format': '%v'},
     {'text': 'XX%', 'format': '%p%'},
-    {'text': 'mm:ss'}
+    {'text': 'mm:ss', 'format': 'mm:ss'}
 ]
 TEXT_OPTIONS = []
 for text_format in TEXT_FORMAT:
@@ -382,6 +382,7 @@ class AnkiProgressBar(object):
     _qProgressBar = None
     _maxValue = 1
     _currentValue = 1
+    _textFormat = ''
 
     def __init__(self, config, maxValue):
         self._qProgressBar = qt.QProgressBar()
@@ -408,6 +409,8 @@ class AnkiProgressBar(object):
         '''
         self._currentValue = self._maxValue
         self._validateUpdateCurrentValue()
+        if self._textFormat == 'mm:ss':
+            self._updateTimerText()
 
     def setMaxValue(self, maxValue):
         '''
@@ -424,6 +427,8 @@ class AnkiProgressBar(object):
         '''
         self._currentValue = currentValue
         self._validateUpdateCurrentValue()
+        if self._textFormat == 'mm:ss':
+            self._updateTimerText()
 
     def incCurrentValue(self, increment):
         '''
@@ -432,6 +437,13 @@ class AnkiProgressBar(object):
         '''
         self._currentValue += increment
         self._validateUpdateCurrentValue()
+        if self._textFormat == 'mm:ss':
+            self._updateTimerText()
+
+    def _updateTimerText(self):
+        minutes = self._currentValue / 60
+        seconds = self._currentValue % 60
+        self._qProgressBar.setFormat('{0:01d}:{1:02d}'.format(minutes, seconds))
 
     def getCurrentValue(self):
         '''
@@ -446,6 +458,7 @@ class AnkiProgressBar(object):
         self._qProgressBar.setTextVisible(options['text'] != 0)  # 0 is the index of None
         textFormat = TEXT_FORMAT[options['text']]
         if 'format' in textFormat:
+            self._textFormat = textFormat['format']
             self._qProgressBar.setFormat(textFormat['format'])
 
         customStyle = STYLE_OPTIONS[options['customStyle']] \

--- a/lifedrain/lifedrain.py
+++ b/lifedrain/lifedrain.py
@@ -443,7 +443,7 @@ class AnkiProgressBar(object):
         '''
         Sets the style of the bar.
         '''
-        self._qProgressBar.setTextVisible(options['text'] != 'None')
+        self._qProgressBar.setTextVisible(options['text'] != 0)  # 0 is the index of None
         textFormat = TEXT_FORMAT[options['text']]
         if 'format' in textFormat:
             self._qProgressBar.setFormat(textFormat['format'])

--- a/lifedrain/lifedrain.py
+++ b/lifedrain/lifedrain.py
@@ -440,11 +440,6 @@ class AnkiProgressBar(object):
         if self._textFormat == 'mm:ss':
             self._updateTimerText()
 
-    def _updateTimerText(self):
-        minutes = self._currentValue / 60
-        seconds = self._currentValue % 60
-        self._qProgressBar.setFormat('{0:01d}:{1:02d}'.format(minutes, seconds))
-
     def getCurrentValue(self):
         '''
         Gets the current value of the bar.
@@ -525,6 +520,11 @@ class AnkiProgressBar(object):
         elif self._currentValue < 0:
             self._currentValue = 0
         self._qProgressBar.setValue(self._currentValue)
+
+    def _updateTimerText(self):
+        minutes = self._currentValue / 60
+        seconds = self._currentValue % 60
+        self._qProgressBar.setFormat('{0:01d}:{1:02d}'.format(minutes, seconds))
 
     def _dockAt(self, place):
         '''


### PR DESCRIPTION
Resolves #6 

Planned bar texts to be implemented:
- [x] `None`
- [x] `current/total (XX%)`
- [x] `current/total`
- [x] `current`
- [x] `XX%`
- [x] `mm:ss`

`None` is the default option.
It is possible to choose the text color. Should disable its option if text format is `None`.