### PR TITLE
Allow disabling Life Drain

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ The [Progress Bar](https://ankiweb.net/shared/info/2091361802) addon showed me t
 And then I just thought: why not to have a life bar with drain in Anki?
 
 ## CHANGELOG
+- **2018-12-01**: Fix sync failing.
 - **2018-12-01**: Make the settings more flexible (max life with 4 digits and drain 0) and bugfix.
 - **2018-11-23**: Added option to show remaining life as text.
 - **2018-10-27**: Fixed keyboard shortcut affecting other addons on Anki 2.1.

--- a/lifedrain/lifedrain.py
+++ b/lifedrain/lifedrain.py
@@ -660,16 +660,16 @@ class DeckProgressBarManager(object):
         del self._ankiProgressBar
         self._ankiProgressBar = ankiProgressBar
 
-    def recover(self, increment=True):
+    def recover(self, increment=True, value=None):
         '''
         Abstraction for recovering life, increments the bar if increment is True (default).
         '''
         multiplier = 1
         if not increment:
             multiplier = -1
-        self._ankiProgressBar.incCurrentValue(
-            multiplier * self._barInfo[self._currentDeck]['recoverValue']
-        )
+        if value is None:
+            value = self._barInfo[self._currentDeck]['recoverValue']
+        self._ankiProgressBar.incCurrentValue(multiplier * value)
 
         self._barInfo[self._currentDeck]['currentValue'] = \
             self._ankiProgressBar.getCurrentValue()
@@ -709,7 +709,7 @@ def timerTrigger():
     It decrements the bar by 1 unit.
     '''
     lifeDrain = getLifeDrain()
-    lifeDrain.deckBarManager.getBar().incCurrentValue(-1)
+    lifeDrain.deckBarManager.recover(False, 1)
 
 
 def afterStateChange(state, oldState):

--- a/lifedrain/lifedrain.py
+++ b/lifedrain/lifedrain.py
@@ -776,11 +776,13 @@ def showQuestion():
     Called when a question is shown.
     '''
     lifeDrain = getLifeDrain()
-    activateTimer()
-    if lifeDrain.status['reviewed']:
-        lifeDrain.deckBarManager.recover()
-    lifeDrain.status['reviewed'] = False
-    lifeDrain.status['newCardState'] = False
+
+    if not lifeDrain.disable:
+        activateTimer()
+        if lifeDrain.status['reviewed']:
+            lifeDrain.deckBarManager.recover()
+        lifeDrain.status['reviewed'] = False
+        lifeDrain.status['newCardState'] = False
 
 
 def showAnswer():
@@ -788,8 +790,10 @@ def showAnswer():
     Called when an answer is shown.
     '''
     lifeDrain = getLifeDrain()
-    activateTimer()
-    lifeDrain.status['reviewed'] = True
+
+    if not lifeDrain.disable:
+        activateTimer()
+        lifeDrain.status['reviewed'] = True
 
 
 def undo():
@@ -797,10 +801,12 @@ def undo():
     Deals with undoing.
     '''
     lifeDrain = getLifeDrain()
-    if lifeDrain.status['screen'] == 'review' and not lifeDrain.status['newCardState']:
-        lifeDrain.status['reviewed'] = False
-        lifeDrain.deckBarManager.recover(False)
-    lifeDrain.status['newCardState'] = False
+
+    if not lifeDrain.disable:
+        if lifeDrain.status['screen'] == 'review' and not lifeDrain.status['newCardState']:
+            lifeDrain.status['reviewed'] = False
+            lifeDrain.deckBarManager.recover(False)
+        lifeDrain.status['newCardState'] = False
 
 
 def leech(card):
@@ -840,7 +846,7 @@ def activateTimer():
     Activates the timer that reduces the bar.
     '''
     lifeDrain = getLifeDrain()
-    if not lifeDrain.timer.isActive():
+    if not lifeDrain.disable and lifeDrain.timer is not None and not lifeDrain.timer.isActive():
         lifeDrain.timer.start()
 
 
@@ -849,7 +855,7 @@ def toggleTimer():
     Toggle the timer to pause/unpause the drain.
     '''
     lifeDrain = getLifeDrain()
-    if lifeDrain.timer:
+    if not lifeDrain.disable and lifeDrain.timer is not None:
         if lifeDrain.timer.isActive():
             lifeDrain.timer.stop()
         else:

--- a/lifedrain/lifedrain.py
+++ b/lifedrain/lifedrain.py
@@ -676,7 +676,7 @@ class DeckProgressBarManager(object):
 
     def barVisible(self, visible):
         '''
-        Hides the Progress Bar
+        Sets the visibility of the Progress Bar
         '''
         if visible:
             self._ankiProgressBar.show()

--- a/lifedrain/lifedrain.py
+++ b/lifedrain/lifedrain.py
@@ -314,9 +314,7 @@ def globalSaveConf(self):
             'customStyle': conf.get('barStyle', DEFAULTS['barStyle'])
         }
     }
-    progressBar = AnkiProgressBar(
-        config, lifeDrain.deckBarManager.getBar().getCurrentValue()
-    )
+    progressBar = AnkiProgressBar(config, 100)
     lifeDrain.deckBarManager.updateAnkiProgressBar(progressBar)
 
 
@@ -371,7 +369,7 @@ def saveDeckConf(self):
     self.conf['maxLife'] = self.form.maxLifeInput.value()
     self.conf['recover'] = self.form.recoverInput.value()
     self.conf['currentValue'] = self.form.currentValueInput.value()
-    lifeDrain.deckBarManager.updateDeckConf(self.deck['id'], self.conf)
+    lifeDrain.deckBarManager.setDeckConf(self.deck['id'], self.conf)
 
 
 def customStudyLifeDrainUi(self, Dialog):
@@ -641,7 +639,7 @@ class DeckProgressBarManager(object):
         '''
         return self._barInfo[str(deckId)]
 
-    def updateDeckConf(self, deckId, conf):
+    def setDeckConf(self, deckId, conf):
         '''
         Updates deck's current state.
         '''
@@ -676,11 +674,14 @@ class DeckProgressBarManager(object):
         self._barInfo[self._currentDeck]['currentValue'] = \
             self._ankiProgressBar.getCurrentValue()
 
-    def getBar(self):
+    def barVisible(self, visible):
         '''
-        Gets AnkiProgressBar instance.
+        Hides the Progress Bar
         '''
-        return self._ankiProgressBar
+        if visible:
+            self._ankiProgressBar.show()
+        else:
+            self._ankiProgressBar.hide()
 
 
 # Remove separator strip
@@ -728,12 +729,12 @@ def afterStateChange(state, oldState):
     lifeDrain.status['screen'] = state
 
     if state == 'deckBrowser':
-        lifeDrain.deckBarManager.getBar().hide()
+        lifeDrain.deckBarManager.barVisible(False)
         lifeDrain.deckBarManager.setDeck(None)
     else:
         if mw.col is not None:
             lifeDrain.deckBarManager.setDeck(mw.col.decks.current()['id'])
-        lifeDrain.deckBarManager.getBar().show()
+        lifeDrain.deckBarManager.barVisible(True)
 
     if state == 'review':
         lifeDrain.timer.start()

--- a/lifedrain/lifedrain.py
+++ b/lifedrain/lifedrain.py
@@ -109,9 +109,10 @@ def getLifeDrain():
         progressBar.hide()
         lifeDrain.deckBarManager = DeckProgressBarManager(progressBar)
 
-    # Keep deck list always updated
-    for deckId in mw.col.decks.allIds():
-        lifeDrain.deckBarManager.addDeck(deckId, mw.col.decks.confForDid(deckId))
+    if mw.col is not None:
+        # Keep deck list always updated
+        for deckId in mw.col.decks.allIds():
+            lifeDrain.deckBarManager.addDeck(deckId, mw.col.decks.confForDid(deckId))
 
     return lifeDrain
 
@@ -730,7 +731,8 @@ def afterStateChange(state, oldState):
         lifeDrain.deckBarManager.getBar().hide()
         lifeDrain.deckBarManager.setDeck(None)
     else:
-        lifeDrain.deckBarManager.setDeck(mw.col.decks.current()['id'])
+        if mw.col is not None:
+            lifeDrain.deckBarManager.setDeck(mw.col.decks.current()['id'])
         lifeDrain.deckBarManager.getBar().show()
 
     if state == 'review':


### PR DESCRIPTION
Resolves #14 

- [x] Depends on #17 

Add an option in the Preferences that allow disabling the add-on.
Some people prefer to use it only sometimes.